### PR TITLE
Add Kafka metaData Information

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.0</version>
+                <version>3.7.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/src/main/java/org/wso2/carbon/connector/KafkaProduceConnector.java
+++ b/src/main/java/org/wso2/carbon/connector/KafkaProduceConnector.java
@@ -185,7 +185,7 @@ public class KafkaProduceConnector extends AbstractConnector {
 
         try {
             if (producer != null) {
-                send(producer, topic, partitionNo, key, message, headers,messageContext);
+                send(producer, topic, partitionNo, key, message, headers, messageContext);
             } else {
                 //If any error occurs while getting the connection from the pool.
                 sendWithoutPool(messageContext, topic, partitionNo, key, message, headers);
@@ -219,7 +219,7 @@ public class KafkaProduceConnector extends AbstractConnector {
         KafkaConnection kafkaConnection = new KafkaConnection();
         KafkaProducer<String, String> producer = kafkaConnection.createNewConnection(messageContext);
         try {
-            send(producer, topic, partitionNo, key, message, headers,messageContext);
+            send(producer, topic, partitionNo, key, message, headers, messageContext);
         } catch (Exception e) {
             handleException("Kafka producer connector:" +
                     "Error sending the message to broker lists without connection Pool", e, messageContext);

--- a/src/main/java/org/wso2/carbon/connector/KafkaProduceConnector.java
+++ b/src/main/java/org/wso2/carbon/connector/KafkaProduceConnector.java
@@ -25,8 +25,10 @@ import org.apache.axis2.transport.base.BaseUtils;
 import org.apache.axis2.util.MessageProcessorSelector;
 import org.apache.commons.io.output.WriterOutputStream;
 import org.apache.commons.lang.StringUtils;
+import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseLog;
@@ -41,6 +43,8 @@ import java.io.OutputStream;
 import java.io.StringWriter;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 /**
  * Produce the messages to the kafka brokers.
@@ -142,12 +146,20 @@ public class KafkaProduceConnector extends AbstractConnector {
      * @param headers
      */
     private void send(KafkaProducer<String, String> producer, String topic, String partitionNo, String key,
-                      String message, org.apache.kafka.common.header.Headers headers) {
-        if (partitionNo == null) {
-            producer.send(new ProducerRecord<String, String>(topic, message));
+                      String message, org.apache.kafka.common.header.Headers headers, MessageContext messageContext)
+            throws ExecutionException, InterruptedException {
+        Future<RecordMetadata> metaData;
+        if (StringUtils.isEmpty(partitionNo)) {
+            metaData = producer.send(new ProducerRecord<String, String>(topic, message));
+            messageContext.setProperty("topic", metaData.get().topic());
+            messageContext.setProperty("offset", metaData.get().offset());
+            messageContext.setProperty("partition", metaData.get().partition());
             producer.flush();
         } else {
-            producer.send(new ProducerRecord<>(topic, Integer.parseInt(partitionNo), key, message, headers));
+            metaData = producer.send(new ProducerRecord<>(topic, Integer.parseInt(partitionNo), key, message, headers));
+            messageContext.setProperty("topic", metaData.get().topic());
+            messageContext.setProperty("offset",  metaData.get().offset());
+            messageContext.setProperty("partition", metaData.get().partition());
             producer.flush();
         }
     }
@@ -174,7 +186,7 @@ public class KafkaProduceConnector extends AbstractConnector {
 
         try {
             if (producer != null) {
-                send(producer, topic, partitionNo, key, message, headers);
+                send(producer, topic, partitionNo, key, message, headers,messageContext);
             } else {
                 //If any error occurs while getting the connection from the pool.
                 sendWithoutPool(messageContext, topic, partitionNo, key, message, headers);
@@ -208,7 +220,7 @@ public class KafkaProduceConnector extends AbstractConnector {
         KafkaConnection kafkaConnection = new KafkaConnection();
         KafkaProducer<String, String> producer = kafkaConnection.createNewConnection(messageContext);
         try {
-            send(producer, topic, partitionNo, key, message, headers);
+            send(producer, topic, partitionNo, key, message, headers,messageContext);
         } catch (Exception e) {
             handleException("Kafka producer connector:" +
                     "Error sending the message to broker lists without connection Pool", e, messageContext);

--- a/src/main/java/org/wso2/carbon/connector/KafkaProduceConnector.java
+++ b/src/main/java/org/wso2/carbon/connector/KafkaProduceConnector.java
@@ -25,7 +25,6 @@ import org.apache.axis2.transport.base.BaseUtils;
 import org.apache.axis2.util.MessageProcessorSelector;
 import org.apache.commons.io.output.WriterOutputStream;
 import org.apache.commons.lang.StringUtils;
-import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;


### PR DESCRIPTION
## Purpose
Add the RecordMetadata information of published message

## Goals
Get the status of kafka published message

## Approach
Add the RecordMetadata information into the message context

## User stories
N/A

## Release note
To ack the back-end with status information once the message published using kafka producer

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK versions - 1.8
Operating systems - Ubuntu
 
## Learning
Learned about kafka