### PR TITLE
Add custom header synapse Xpath support

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/KafkaProduceConnector.java
+++ b/src/main/java/org/wso2/carbon/connector/KafkaProduceConnector.java
@@ -104,8 +104,8 @@ public class KafkaProduceConnector extends AbstractConnector {
         for (String keyValue : propertiesMap.keySet()) {
             if (keyValue.startsWith(key)) {
                 Value propertyValue = (Value) propertiesMap.get(keyValue);
-                headers.add(keyValue.substring(key.length() + 1, keyValue.length()), propertyValue
-                        .getKeyValue().getBytes());
+                headers.add(keyValue.substring(key.length() + 1, keyValue.length()), propertyValue.
+                        evaluateValue(messageContext).getBytes());
             }
         }
         return headers;


### PR DESCRIPTION
## Purpose
Kafka connector custom headers do not support for the synapse functions.  This fix will enable the synapse XPath support.
Ex -

```
<kafkaTransport.publishMessages>
            <topic>test</topic>
            <test.reProcessCount>{get-property('repProcessCountTemp')}</test.reProcessCount>
 </kafkaTransport.publishMessages>

<kafkaTransport.publishMessages>
            <topic>test</topic>
            <test.reProcessCount>{$ctx:repProcessCountTemp}</test.reProcessCount>
 </kafkaTransport.publishMessages>
```

