### PR TITLE
Make the 'key' parameter configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.${connector.name}</artifactId>
-    <version>2.0.9</version>
+    <version>2.0.10</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Mediation Library Connector For kafkaTransport</name>
     <url>http://wso2.org</url>

--- a/src/main/java/org/wso2/carbon/connector/KafkaConnectConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/KafkaConnectConstants.java
@@ -76,6 +76,7 @@ public class KafkaConnectConstants {
     // Configuration properties parameter
     public static final String PARAM_TOPIC = "topic";
     public static final String PARTITION_NO = "partitionNo";
+    public static final String PARAM_KEY = "key";
 
     public static final String METHOD_NAME = "publishMessages:";
 

--- a/src/main/java/org/wso2/carbon/connector/KafkaProduceConnector.java
+++ b/src/main/java/org/wso2/carbon/connector/KafkaProduceConnector.java
@@ -60,8 +60,12 @@ public class KafkaProduceConnector extends AbstractConnector {
                     .getProperty(KafkaConnectConstants.CONNECTION_POOL_MAX_SIZE);
             // Read the topic from the parameter
             String topic = lookupTemplateParameter(messageContext, KafkaConnectConstants.PARAM_TOPIC);
-            //Generate the key.
-            String key = String.valueOf(UUID.randomUUID());
+            //Read the key from parameters
+            String key = lookupTemplateParameter(messageContext, KafkaConnectConstants.PARAM_KEY);
+            // If key does not exist, generate.
+            if (StringUtils.isBlank(key)) {
+                key = String.valueOf(UUID.randomUUID());
+            }
             //Read the partition No from the parameter
             String partitionNo = lookupTemplateParameter(messageContext, KafkaConnectConstants.PARTITION_NO);
             String message = getMessage(messageContext);

--- a/src/main/resources/kafka_produce/kafkaProduce-template.xml
+++ b/src/main/resources/kafka_produce/kafkaProduce-template.xml
@@ -21,6 +21,7 @@
     <parameter name="topic" description="maintains feeds of messages in categories"/>
     <parameter name="message" description="the messages can be xml or json message"/>
     <parameter name="partitionNo" description="The value of the partition Number"/>
+    <parameter name="key" description="The key of the message"/>
     <sequence>
         <class name="org.wso2.carbon.connector.KafkaProduceConnector"/>
     </sequence>


### PR DESCRIPTION
## Purpose
Make the `key` parameter configurable. If not provided a random UUID will be used.

Fixes: https://github.com/wso2/api-manager/issues/1554