### PR TITLE
Optional parameters added

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/KafkaConfigConnector.java
+++ b/src/main/java/org/wso2/carbon/connector/KafkaConfigConnector.java
@@ -158,24 +158,9 @@ public class KafkaConfigConnector extends AbstractConnector {
                         KafkaConnectConstants.DEFAULT_SEND_BUFFER_BYTES);
             }
 
-            if (StringUtils.isEmpty(timeoutTime)) {
-                messageContext.setProperty(KafkaConnectConstants.KAFKA_TIMEOUT_TIME,
-                        KafkaConnectConstants.DEFAULT_TIMEOUT_TIME);
-            }
-
-            if (StringUtils.isEmpty(blockOnBufferFull)) {
-                messageContext.setProperty(KafkaConnectConstants.KAFKA_BLOCK_ON_BUFFER_FULL,
-                        KafkaConnectConstants.DEFAULT_BLOCK_ON_BUFFER_FULL);
-            }
-
             if (StringUtils.isEmpty(maxInFlightRequestsPerConnection)) {
                 messageContext.setProperty(KafkaConnectConstants.KAFKA_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION,
                         KafkaConnectConstants.DEFAULT_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION);
-            }
-
-            if (StringUtils.isEmpty(metadataFetchTimeout)) {
-                messageContext.setProperty(KafkaConnectConstants.KAFKA_METADATA_FETCH_TIMEOUT,
-                        KafkaConnectConstants.DEFAULT_METADATA_FETCH_TIMEOUT);
             }
 
             if (StringUtils.isEmpty(metadataMaximumAge)) {

--- a/src/main/java/org/wso2/carbon/connector/KafkaConnection.java
+++ b/src/main/java/org/wso2/carbon/connector/KafkaConnection.java
@@ -214,12 +214,20 @@ public class KafkaConnection {
             producerConfigProperties.put(KafkaConnectConstants.SSL_TRUSTSTORE_TYPE, sslTruststoreType);
         }
 
-        producerConfigProperties.put(KafkaConnectConstants.TIMEOUT_TIME, timeoutTime);
-        producerConfigProperties.put(KafkaConnectConstants.BLOCK_ON_BUFFER_FULL, blockOnBufferFull);
+        if (StringUtils.isNotEmpty(timeoutTime)) {
+            producerConfigProperties.put(KafkaConnectConstants.TIMEOUT_TIME, timeoutTime);
+        }
+        
+        if (StringUtils.isNotEmpty(blockOnBufferFull)) {
+            producerConfigProperties.put(KafkaConnectConstants.BLOCK_ON_BUFFER_FULL, blockOnBufferFull);
+        }
+
         producerConfigProperties
                 .put(KafkaConnectConstants
                         .MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, maxInFlightRequestsPerConnection);
-        producerConfigProperties.put(KafkaConnectConstants.METADATA_FETCH_TIMEOUT, metadataFetchTimeout);
+        if (StringUtils.isNotEmpty(metadataFetchTimeout)) {
+            producerConfigProperties.put(KafkaConnectConstants.METADATA_FETCH_TIMEOUT, metadataFetchTimeout);
+        }
         producerConfigProperties.put(KafkaConnectConstants.METADATA_MAXIMUM_AGE, metadataMaximumAge);
         producerConfigProperties.put(KafkaConnectConstants.METRIC_REPORTERS, metricReporters);
         producerConfigProperties.put(KafkaConnectConstants.METRICS_NUM_SAMPLES, metricsNumSamples);


### PR DESCRIPTION
## Purpose
Avoids WARN {org.apache.kafka.clients.producer.ProducerConfig} - The configuration * was supplied but isn't a known config.
timeout.ms, block.on.buffer.full and metadata.fetch.timeout.ms properties where deprecated in https://github.com/apache/kafka/commit/4efe4ac6d785c708ec623a6dca24ae34d4b29097