### PR TITLE
Add missing parameters to uischema and kafkaProduce template

### DIFF
--- a/src/main/resources/kafka_produce/kafkaProduce-template.xml
+++ b/src/main/resources/kafka_produce/kafkaProduce-template.xml
@@ -21,6 +21,7 @@
     <parameter name="topic" description="maintains feeds of messages in categories"/>
     <parameter name="message" description="the messages can be xml or json message"/>
     <parameter name="partitionNo" description="The value of the partition Number"/>
+    <parameter name="contentType" description="The value of the Content Type"/>
     <parameter name="key" description="The key of the message"/>
     <parameter name="keySchema" description="The avro schema of the key"/>
     <parameter name="keySchemaId" description="The id of the registered key schema"/>

--- a/src/main/resources/uischema/connection.json
+++ b/src/main/resources/uischema/connection.json
@@ -447,6 +447,17 @@
           {
             "type": "attribute",
             "value": {
+              "name": "saslMechanism",
+              "displayName": "SASL Mechanism",
+              "inputType": "stringOrExpression",
+              "defaultValue": "",
+              "required": "false",
+              "helpTip":""
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
               "name": "securityProtocol",
               "displayName": "Security Protocol",
               "inputType": "stringOrExpression",


### PR DESCRIPTION
## Purpose
> Add following missing parameters to Kafka connector.

1. Add saslMechanism to uischema 
2. Add contentType to kafkaProduce template

Fixes:  #73 