### PR TITLE
Support SASL_SSL security protocol with OAUTHBEARER mechanism

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/KafkaConfigConnector.java
+++ b/src/main/java/org/wso2/carbon/connector/KafkaConfigConnector.java
@@ -88,7 +88,8 @@ public class KafkaConfigConnector extends AbstractConnector implements ManagedLi
                     .getProperty(KafkaConnectConstants.KAFKA_RECONNECT_BACKOFF_TIME);
             String retryBackoffTime = (String) messageContext
                     .getProperty(KafkaConnectConstants.KAFKA_RETRY_BACKOFF_TIME);
-
+            String reconnectBackoffTimeMax = (String) messageContext
+                    .getProperty(KafkaConnectConstants.KAFKA_RECONNECT_BACKOFF_MAX_TIME);
             if (StringUtils.isEmpty(ack)) {
                 messageContext.setProperty(KafkaConnectConstants.KAFKA_ACKS,
                         KafkaConnectConstants.DEFAULT_ACK);

--- a/src/main/java/org/wso2/carbon/connector/KafkaConnectConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/KafkaConnectConstants.java
@@ -64,12 +64,22 @@ public class KafkaConnectConstants {
     public static final String METRICS_NUM_SAMPLES = "metrics.num.samples";
     public static final String METRICS_SAMPLE_WINDOW = "metrics.sample.window.ms";
     public static final String RECONNECT_BACKOFF_TIME = "reconnect.backoff.ms";
+    public static final String RECONNECT_BACKOFF_MAX_MS = "reconnect.backoff.max.ms";
     public static final String RETRY_BACKOFF_TIME = "retry.backoff.ms";
     public static final String SASL_KERBEROS_KINIT_CMD = "sasl.kerberos.kinit.cmd";
     public static final String SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN = "sasl.kerberos.min.time.before.relogin";
     public static final String SASL_KERBEROS_TICKET_RENEW_JITTER = "sasl.kerberos.ticket.renew.jitter";
     public static final String SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR
             = "sasl.kerberos.ticket.renew.window.factor";
+    public static final String SASL_OAUTHBEARER_TOKEN_ENDPOINT = "sasl.oauthbearer.token.endpoint.url";
+    public static final String SASL_OAUTHBEARER_SCOPE_CLAIM_NAME = "sasl.oauthbearer.scope.claim.name";
+    public static final String SASL_LOGIN_CONNECT_TIMEOUT = "sasl.login.connect.timeout.ms";
+    public static final String SASL_LOGIN_READ_TIMEOUT = "sasl.login.read.timeout.ms";
+    public static final String SASL_LOGIN_RETRY_BACKOFF = "sasl.login.retry.backoff.ms";
+    public static final String SASL_LOGIN_RETRY_BACKOFF_MAX = "sasl.login.retry.backoff.max.ms";
+    public static final String SASL_LOGIN_CALLBACK_HANDLER_CLASS = "sasl.login.callback.handler.class";
+    public static final String ENABLE_IDEMPOTENCE = "enable.idempotence";
+    public static final String MESSAGE_SEND_MAX_RETRIES = "message.send.max.retries";
     public static final String SSL_CIPHER_SUITES = "ssl.cipher.suites";
     public static final String SSL_ENDPOINT_IDENTIFICATION_ALGORITHM = "ssl.endpoint.identification.algorithm";
     public static final String SSL_KEYMANAGER_ALGORITHM = "ssl.keymanager.algorithm";
@@ -127,6 +137,7 @@ public class KafkaConnectConstants {
     public static final String KAFKA_METRICS_NUM_SAMPLES = "kafka.metricsNumSamples";
     public static final String KAFKA_METRICS_SAMPLE_WINDOW = "kafka.metricsSampleWindow";
     public static final String KAFKA_RECONNECT_BACKOFF_TIME = "kafka.reconnectBackoff";
+    public static final String KAFKA_RECONNECT_BACKOFF_MAX_TIME = "kafka.reconnectBackoffMax";
     public static final String KAFKA_RETRY_BACKOFF_TIME = "kafka.retryBackoff";
     public static final String KAFKA_SASL_KERBEROS_KINIT_CMD = "kafka.saslKerberosKinitCmd";
     public static final String
@@ -134,6 +145,15 @@ public class KafkaConnectConstants {
     public static final String KAFKA_SASL_KERBEROS_TICKET_RENEW_JITTER = "kafka.saslKerberosTicketRenewJitter";
     public static final String KAFKA_SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR
             = "kafka.saslKerberosTicketRenewWindowFactor";
+    public static final String KAFKA_ENABLE_IDEMPOTENCE = "kafka.enableIdempotence";
+    public static final String KAFKA_MESSAGE_SEND_MAX_RETRIES = "kafka.messageSendMaxRetries";
+    public static final String KAFKA_SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL = "kafka.saslOauthbearerTokenEndpointUrl";
+    public static final String KAFKA_SASL_LOGIN_CALLBACK_HANDLER_CLASS = "kafka.saslLoginCallbackHandlerClass";
+    public static final String KAFKA_SASL_OAUTHBEARER_SCOPE_CLAIM_NAME = "kafka.saslOauthbearerScopeClaimName";
+    public static final String KAFKA_SASL_LOGIN_CONNECT_TIMEOUT = "kafka.saslLoginConnectTimeout";
+    public static final String KAFKA_SASL_LOGIN_READ_TIMEOUT = "kafka.saslLoginReadTimeout";
+    public static final String KAFKA_SASL_LOGIN_RETRY_BACKOFF = "kafka.saslLoginRetryBackoff";
+    public static final String KAFKA_SASL_LOGIN_RETRY_BACKOFF_MAX = "kafka.saslLoginRetryBackoffMax";
     public static final String KAFKA_SSL_CIPHER_SUITES = "kafka.sslCipherSuites";
     public static final String KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM =
             "kafka.sslEndpointIdentificationAlgorithm";

--- a/src/main/java/org/wso2/carbon/connector/connection/KafkaConnection.java
+++ b/src/main/java/org/wso2/carbon/connector/connection/KafkaConnection.java
@@ -128,6 +128,8 @@ public class KafkaConnection implements Connection {
                 .getProperty(KafkaConnectConstants.KAFKA_RECONNECT_BACKOFF_TIME);
         String retryBackoffTime = (String) messageContext
                 .getProperty(KafkaConnectConstants.KAFKA_RETRY_BACKOFF_TIME);
+        String reconnectBackoffTimeMax = (String) messageContext
+                .getProperty(KafkaConnectConstants.KAFKA_RECONNECT_BACKOFF_MAX_TIME);
         String saslKerberosKinitCmd = (String) messageContext
                 .getProperty(KafkaConnectConstants.KAFKA_SASL_KERBEROS_KINIT_CMD);
         String saslKerberosMinTimeBeforeLogin = (String) messageContext
@@ -146,6 +148,24 @@ public class KafkaConnection implements Connection {
                 .getProperty(KafkaConnectConstants.KAFKA_SSL_SECURE_RANDOM_IMPLEMENTATION);
         String sslTrustmanagerAlgorithm = (String) messageContext
                 .getProperty(KafkaConnectConstants.KAFKA_SSL_TRUSTMANAGER_ALGORITHM);
+        String saslOauthbearerTokenEndpointUrl = (String) messageContext
+                .getProperty(KafkaConnectConstants.KAFKA_SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL);
+        String saslLoginCallbackHandlerClass = (String) messageContext
+                .getProperty(KafkaConnectConstants.KAFKA_SASL_LOGIN_CALLBACK_HANDLER_CLASS);
+        String saslOauthbearerScopeClaimName = (String) messageContext
+                .getProperty(KafkaConnectConstants.KAFKA_SASL_OAUTHBEARER_SCOPE_CLAIM_NAME);
+        String saslLoginConnectTimeout = (String) messageContext
+                .getProperty(KafkaConnectConstants.KAFKA_SASL_LOGIN_CONNECT_TIMEOUT);
+        String saslLoginReadTimeout = (String) messageContext
+                .getProperty(KafkaConnectConstants.KAFKA_SASL_LOGIN_READ_TIMEOUT);
+        String saslLoginRetryBackoff = (String) messageContext
+                .getProperty(KafkaConnectConstants.KAFKA_SASL_LOGIN_RETRY_BACKOFF);
+        String saslLoginRetryBackoffMax = (String) messageContext
+                .getProperty(KafkaConnectConstants.KAFKA_SASL_LOGIN_RETRY_BACKOFF_MAX);
+        String enableIdempotence = (String) messageContext
+                .getProperty(KafkaConnectConstants.KAFKA_ENABLE_IDEMPOTENCE);
+        String messageSendMaxRetries = (String) messageContext
+                .getProperty(KafkaConnectConstants.KAFKA_MESSAGE_SEND_MAX_RETRIES);
         String subjectNameStrategy = (String) messageContext
                 .getProperty(KafkaConnectConstants.KAFKA_SUBJECT_NAME_STRATEGY);
         String useLatestVersion = (String) messageContext
@@ -162,6 +182,33 @@ public class KafkaConnection implements Connection {
         producerConfigProperties.put(KafkaConnectConstants.COMPRESSION_TYPE, compressionCodec);
         producerConfigProperties.put(KafkaConnectConstants.RETRIES, retries);
 
+        if (StringUtils.isNotEmpty(enableIdempotence)) {
+            producerConfigProperties.put(KafkaConnectConstants.ENABLE_IDEMPOTENCE, enableIdempotence);
+        }
+        if (StringUtils.isNotEmpty(messageSendMaxRetries)) {
+            producerConfigProperties.put(KafkaConnectConstants.MESSAGE_SEND_MAX_RETRIES, messageSendMaxRetries);
+        }
+        if (StringUtils.isNotEmpty(saslOauthbearerTokenEndpointUrl)) {
+            producerConfigProperties.put(KafkaConnectConstants.SASL_OAUTHBEARER_TOKEN_ENDPOINT, saslOauthbearerTokenEndpointUrl);
+        }
+        if (StringUtils.isNotEmpty(saslOauthbearerScopeClaimName)) {
+            producerConfigProperties.put(KafkaConnectConstants.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME, saslOauthbearerScopeClaimName);
+        }
+        if (StringUtils.isNotEmpty(saslLoginConnectTimeout)) {
+            producerConfigProperties.put(KafkaConnectConstants.SASL_LOGIN_CONNECT_TIMEOUT, saslLoginConnectTimeout);
+        }
+        if (StringUtils.isNotEmpty(saslLoginReadTimeout)) {
+            producerConfigProperties.put(KafkaConnectConstants.SASL_LOGIN_READ_TIMEOUT, saslLoginReadTimeout);
+        }
+        if (StringUtils.isNotEmpty(saslLoginRetryBackoff)) {
+            producerConfigProperties.put(KafkaConnectConstants.SASL_LOGIN_RETRY_BACKOFF, saslLoginRetryBackoff);
+        }
+        if (StringUtils.isNotEmpty(saslLoginRetryBackoffMax)) {
+            producerConfigProperties.put(KafkaConnectConstants.SASL_LOGIN_RETRY_BACKOFF_MAX, saslLoginRetryBackoffMax);
+        }
+        if (StringUtils.isNotEmpty(saslLoginCallbackHandlerClass)) {
+            producerConfigProperties.put(KafkaConnectConstants.SASL_LOGIN_CALLBACK_HANDLER_CLASS, saslLoginCallbackHandlerClass);
+        }
         if (StringUtils.isNotEmpty(basicAuthCredentialsSource)) {
             producerConfigProperties.put(KafkaAvroSerializerConfig.BASIC_AUTH_CREDENTIALS_SOURCE, basicAuthCredentialsSource);
         }
@@ -240,6 +287,10 @@ public class KafkaConnection implements Connection {
 
         if (StringUtils.isNotEmpty(sslTruststoreType)) {
             producerConfigProperties.put(KafkaConnectConstants.SSL_TRUSTSTORE_TYPE, sslTruststoreType);
+        }
+
+        if (StringUtils.isNotEmpty(reconnectBackoffTimeMax)) {
+            producerConfigProperties.put(KafkaConnectConstants.RECONNECT_BACKOFF_MAX_MS, reconnectBackoffTimeMax);
         }
 
         producerConfigProperties.put(KafkaConnectConstants.TIMEOUT_TIME, timeoutTime);

--- a/src/main/resources/kafka_config/init.xml
+++ b/src/main/resources/kafka_config/init.xml
@@ -143,6 +143,24 @@
     <parameter name="autoRegisterSchemas" description="Serializer will/will not attempt to register new schemas"/>
     <parameter name="subjectNameStrategy" description="specify the strategy for determining the subject name under
         which the schema is registered"/>
+    <parameter name="saslOauthbearerTokenEndpoint" description="The URL for the OAuth/OIDC identity provider"/>
+    <parameter name="saslLoginCallbackHandlerClass" description="The fully qualified name of a SASL login callback handler
+    class that implements the AuthenticateCallbackHandler interface."/>
+    <parameter name="saslOauthbearerScopeClaimName" description="(optional) The override name of the scope claim."/>
+    <parameter name="saslLoginConnectTimeout" description="(optional) The duration, in milliseconds, for HTTPS connect
+    timeout."/>
+    <parameter name="saslLoginReadTimeout" description="(optional) The duration, in milliseconds, for HTTPS read timeout."/>
+    <parameter name="saslLoginRetryBackoff" description="(optional) The duration, in milliseconds, to wait between
+    HTTPS call attempts."/>
+    <parameter name="saslLoginRetryBackoffMax" description="(optional) The maximum duration, in milliseconds, for
+    HTTPS call attempts."/>
+    <parameter name="enableIdempotence" description="When set to ‘true’, the producer will ensure that exactly one copy
+    of each message is written in the stream. If ‘false’, producer retries due to broker failures, etc., may write
+    duplicates of the retried message in the stream."/>
+    <parameter name="messageSendMaxRetries" description="This property will cause the producer to automatically retry
+    a failed send request."/>
+    <parameter name="reconnectBackoffMax" description="The maximum amount of time in milliseconds to wait
+    when reconnecting to a broker that has repeatedly failed to connect."/>
     <sequence>
         <property expression="$func:schemaRegistryUrl" name="kafka.schemaRegistryUrl"/>
         <property expression="$func:basicAuthCredentialsSource" name="kafka.basicAuthCredentialsSource"/>
@@ -211,7 +229,16 @@
         <property name="kafka.useLatestVersion" expression="$func:useLatestVersion"/>
         <property name="kafka.autoRegisterSchemas" expression="$func:autoRegisterSchemas"/>
         <property name="kafka.subjectNameStrategy" expression="$func:subjectNameStrategy"/>
-
+        <property name="kafka.saslOauthbearerTokenEndpointUrl" expression="$func:saslOauthbearerTokenEndpoint"/>
+        <property name="kafka.saslOauthbearerScopeClaimName" expression="$func:saslOauthbearerScopeClaimName"/>
+        <property name="kafka.saslLoginConnectTimeout" expression="$func:saslLoginConnectTimeout"/>
+        <property name="kafka.saslLoginReadTimeout" expression="$func:saslLoginReadTimeout"/>
+        <property name="kafka.saslLoginRetryBackoff" expression="$func:saslLoginRetryBackoff"/>
+        <property name="kafka.saslLoginRetryBackoffMax" expression="$func:saslLoginRetryBackoffMax"/>
+        <property name="kafka.saslLoginCallbackHandlerClass" expression="$func:loginCallbackHandlerClass"/>
+        <property name="kafka.enableIdempotence" expression="$func:enableIdempotence"/>
+        <property name="kafka.messageSendMaxRetries" expression="$func:messageSendMaxRetries"/>
+        <property name="kafka.reconnectBackoffMax" expression="$func:reconnectBackoffTimeMax"/>
         <class name="org.wso2.carbon.connector.KafkaConfigConnector"/>
     </sequence>
 </template>

--- a/src/main/resources/uischema/connection.json
+++ b/src/main/resources/uischema/connection.json
@@ -458,6 +458,39 @@
           {
             "type": "attribute",
             "value": {
+              "name": "enableIdempotence",
+              "displayName": "Enable Idempotence",
+              "inputType": "stringOrExpression",
+              "defaultValue": "",
+              "required": "false",
+              "helpTip":"When set to ‘true’, the producer will ensure that exactly one copy of each message is written in the stream. If ‘false’, producer retries due to broker failures, etc., may write duplicates of the retried message in the stream."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "messageSendMaxRetries",
+              "displayName": "Message Send Max Retries",
+              "inputType": "stringOrExpression",
+              "defaultValue": "",
+              "required": "false",
+              "helpTip":"This property will cause the producer to automatically retry a failed send request."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "reconnectBackoffMax",
+              "displayName": "Reconnect Backoff Max",
+              "inputType": "stringOrExpression",
+              "defaultValue": "",
+              "required": "false",
+              "helpTip":"The maximum amount of time in milliseconds to wait when reconnecting to a broker that has repeatedly failed to connect."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
               "name": "securityProtocol",
               "displayName": "Security Protocol",
               "inputType": "stringOrExpression",

--- a/src/main/resources/uischema/secureConnection.json
+++ b/src/main/resources/uischema/secureConnection.json
@@ -381,6 +381,39 @@
           {
             "type": "attribute",
             "value": {
+              "name": "enableIdempotence",
+              "displayName": "Enable Idempotence",
+              "inputType": "stringOrExpression",
+              "defaultValue": "",
+              "required": "false",
+              "helpTip":"When set to ‘true’, the producer will ensure that exactly one copy of each message is written in the stream. If ‘false’, producer retries due to broker failures, etc., may write duplicates of the retried message in the stream."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "messageSendMaxRetries",
+              "displayName": "Message Send Max Retries",
+              "inputType": "stringOrExpression",
+              "defaultValue": "",
+              "required": "false",
+              "helpTip":"This property will cause the producer to automatically retry a failed send request."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "reconnectBackoffMax",
+              "displayName": "Reconnect Backoff Max",
+              "inputType": "stringOrExpression",
+              "defaultValue": "",
+              "required": "false",
+              "helpTip":"The maximum amount of time in milliseconds to wait when reconnecting to a broker that has repeatedly failed to connect."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
               "name": "saslJaasConfig",
               "displayName": "SASL Jaas Config",
               "inputType": "stringOrExpression",
@@ -464,6 +497,83 @@
               "defaultValue": "",
               "required": "false",
               "helpTip":"The login thread sleeps until the specified window factor of time from the last refresh to the ticket's expiry is reached, after which it will try to renew the ticket."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "saslOauthbearerTokenEndpoint",
+              "displayName": "SASL OAUTHBEARER Token Endpoint",
+              "inputType": "stringOrExpression",
+              "defaultValue": "",
+              "required": "false",
+              "helpTip":"The URL for the OAuth/OIDC identity provider."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "saslLoginCallbackHandlerClass",
+              "displayName": "SASL Login Callback Handler Class",
+              "inputType": "stringOrExpression",
+              "defaultValue": "",
+              "required": "false",
+              "helpTip":"The fully qualified name of a SASL login callback handler class that implements the AuthenticateCallbackHandler interface."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "saslOauthbearerScopeClaimName",
+              "displayName": "SASL OAUTHBEARER Scope Claim Name",
+              "inputType": "stringOrExpression",
+              "defaultValue": "",
+              "required": "false",
+              "helpTip":"The override name of the scope claim."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "saslLoginConnectTimeout",
+              "displayName": "SASL Login Connect Timeout",
+              "inputType": "stringOrExpression",
+              "defaultValue": "",
+              "required": "false",
+              "helpTip":"The duration, in milliseconds, for HTTPS connect timeout."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "saslLoginReadTimeout",
+              "displayName": "SASL Login Read Timeout",
+              "inputType": "stringOrExpression",
+              "defaultValue": "",
+              "required": "false",
+              "helpTip":"The duration, in milliseconds, for HTTPS read timeout."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "saslLoginRetryBackoff",
+              "displayName": "SASL Login Retry Backoff",
+              "inputType": "stringOrExpression",
+              "defaultValue": "",
+              "required": "false",
+              "helpTip":"The duration, in milliseconds, to wait between HTTPS call attempts."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "saslLoginRetryBackoffMax",
+              "displayName": "SASL Login Retry Backoff Max Time",
+              "inputType": "stringOrExpression",
+              "defaultValue": "",
+              "required": "false",
+              "helpTip":"The maximum duration, in milliseconds, for HTTPS call attempts."
             }
           },
           {


### PR DESCRIPTION
## Purpose
This PR mainly adds the support to configure the SASL_SSL security protocol with the OAUTHBEARER mechanism. 

- **saslLoginCallbackHandlerClass** - The fully qualified name of a SASL login callback handler class that implements the AuthenticateCallbackHandler interface.
- **saslOauthbearerTokenEndpointUrl** - The URL for the OAuth/OIDC identity provider
- **saslOauthbearerScopeClaimName** - (optional) The override name of the scope claim
- **saslLoginConnectTimeout** - (optional) The duration, in milliseconds, for HTTPS connect timeout
- **saslLoginReadTimeout** - (optional) The duration, in milliseconds, for HTTPS read timeout
- **saslLoginRetryBackoff** - (optional) The duration, in milliseconds, to wait between HTTPS call attempts
- **saslLoginRetryBackoffMax** - (optional) The maximum duration, in milliseconds, for HTTPS call attempts

Also, this adds the below properties as well.

- **enableIdempotence** - When set to ‘true’, the producer will ensure that exactly one copy of each message is written in the stream. If ‘false’, producer retries due to broker failures, etc., may write duplicates of the retried message in the stream.
- **messageSendMaxRetries** - This property will cause the producer to automatically retry a failed send request.
- **reconnectBackoffMax** - The maximum amount of time in milliseconds to wait when reconnecting to a broker that has repeatedly failed to connect.
