### PR TITLE
Support configuring a header-prefix when filtering out the Kafka headers from message context

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/KafkaConnectConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/KafkaConnectConstants.java
@@ -84,7 +84,7 @@ public class KafkaConnectConstants {
     public static final String PARAM_KEY = "key";
 
     public static final String KAFKA_HEADER_PREFIX = "kafka.kafkaHeaderPrefix";
-    public static final String DEFAULT_KAFKA_HEADER_PREFIX = "kafkaHeader_";
+    public static final String DEFAULT_KAFKA_HEADER_PREFIX = "publishMessages:";
 
     // Configuration parameters for kafka connector
     public static final String KAFKA_BROKER_LIST = "kafka.bootstrapServers";

--- a/src/main/java/org/wso2/carbon/connector/KafkaConnectConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/KafkaConnectConstants.java
@@ -83,7 +83,8 @@ public class KafkaConnectConstants {
     public static final String PARTITION_NO = "partitionNo";
     public static final String PARAM_KEY = "key";
 
-    public static final String METHOD_NAME = "publishMessages:";
+    public static final String KAFKA_HEADER_PREFIX = "kafka.kafkaHeaderPrefix";
+    public static final String DEFAULT_KAFKA_HEADER_PREFIX = "kafkaHeader_";
 
     // Configuration parameters for kafka connector
     public static final String KAFKA_BROKER_LIST = "kafka.bootstrapServers";

--- a/src/main/java/org/wso2/carbon/connector/KafkaProduceConnector.java
+++ b/src/main/java/org/wso2/carbon/connector/KafkaProduceConnector.java
@@ -310,12 +310,14 @@ public class KafkaProduceConnector extends AbstractConnector {
     private org.apache.kafka.common.header.Headers getDynamicParameters(MessageContext messageContext) {
 
         org.apache.kafka.common.header.Headers headers = new RecordHeaders();
-        String key = KafkaConnectConstants.METHOD_NAME;
+        String kafkaHeaderPrefix = lookupTemplateParameter(messageContext, KafkaConnectConstants.KAFKA_HEADER_PREFIX);
+        kafkaHeaderPrefix = Objects.isNull(kafkaHeaderPrefix)
+                ? KafkaConnectConstants.DEFAULT_KAFKA_HEADER_PREFIX : kafkaHeaderPrefix.trim();
         Map<String, Object> propertiesMap = (((Axis2MessageContext) messageContext).getProperties());
         for (String keyValue : propertiesMap.keySet()) {
-            if (keyValue.startsWith(key)) {
+            if (keyValue.startsWith(kafkaHeaderPrefix)) {
                 Value propertyValue = (Value) propertiesMap.get(keyValue);
-                headers.add(keyValue.substring(key.length(), keyValue.length()), propertyValue.
+                headers.add(keyValue.substring(kafkaHeaderPrefix.length(), keyValue.length()), propertyValue.
                         evaluateValue(messageContext).getBytes());
             }
         }

--- a/src/main/resources/kafka_produce/kafkaProduce-template.xml
+++ b/src/main/resources/kafka_produce/kafkaProduce-template.xml
@@ -34,6 +34,8 @@
     <parameter name="valueSchemaVersion" description="The version of the registered value/message schema"/>
     <parameter name="valueSchemaSoftDeleted" description="Whether soft deleted value schemas also needed"/>
     <parameter name="value" description="The actual value/message to be sent" />
+    <parameter name="kafkaHeaderPrefix" description="Specify the Kafka header prefix to filter out the Kafka related
+               headers from Message Context."/>
     <sequence>
         <class name="org.wso2.carbon.connector.KafkaProduceConnector"/>
     </sequence>


### PR DESCRIPTION
## Purpose
Currently, the Kafka Inbound Endpoint filters out the Kafka headers from the message context by using the prefix `publishMessages:`. This is not configurable at all. Hence, this PR enable configuring a header-prefix using the below parameter. The default value is `publishMessages:`.

`<kafkaHeaderPrefix>kafkaHeader_</kafkaHeaderPrefix>`
