### PR TITLE
Fix Header Handling issues in Kafka Connector

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/KafkaConnectConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/KafkaConnectConstants.java
@@ -95,7 +95,7 @@ public class KafkaConnectConstants {
     public static final String PARTITION_NO = "partitionNo";
     public static final String PARAM_KEY = "key";
 
-    public static final String KAFKA_HEADER_PREFIX = "kafka.kafkaHeaderPrefix";
+    public static final String KAFKA_HEADER_PREFIX = "kafkaHeaderPrefix";
     public static final String DEFAULT_KAFKA_HEADER_PREFIX = "publishMessages:";
 
     // Configuration parameters for kafka connector

--- a/src/main/java/org/wso2/carbon/connector/KafkaProduceConnector.java
+++ b/src/main/java/org/wso2/carbon/connector/KafkaProduceConnector.java
@@ -95,7 +95,9 @@ public class KafkaProduceConnector extends AbstractConnector {
     public void connect(MessageContext messageContext) {
 
         SynapseLog log = getLog(messageContext);
-        log.auditLog("SEND : send message to  Broker lists");
+        if(log.isDebugEnabled()) {
+            log.auditLog("SEND : send message to  Broker lists");
+        }
         try {
             // Read the parameters
             String topic = lookupTemplateParameter(messageContext, KafkaConnectConstants.PARAM_TOPIC);
@@ -331,9 +333,8 @@ public class KafkaProduceConnector extends AbstractConnector {
         Map<String, Object> propertiesMap = (((Axis2MessageContext) messageContext).getProperties());
         for (String keyValue : propertiesMap.keySet()) {
             if (keyValue.startsWith(kafkaHeaderPrefix)) {
-                Value propertyValue = (Value) propertiesMap.get(keyValue);
-                headers.add(keyValue.substring(kafkaHeaderPrefix.length(), keyValue.length()), propertyValue.
-                        evaluateValue(messageContext).getBytes());
+                String propertyValue = (String) propertiesMap.get(keyValue);
+                headers.add(keyValue.substring(kafkaHeaderPrefix.length(), keyValue.length()), propertyValue.getBytes());
             }
         }
         return headers;

--- a/src/main/java/org/wso2/carbon/connector/KafkaProduceConnector.java
+++ b/src/main/java/org/wso2/carbon/connector/KafkaProduceConnector.java
@@ -831,8 +831,8 @@ public class KafkaProduceConnector extends AbstractConnector {
     private Schema getSchemaFromID(MessageContext messageContext, String schemaID) {
 
         Schema jsonSchema;
-        String connectionName;
-        KafkaConnection connection;
+        String connectionName = null;
+        KafkaConnection connection = null;
         ConnectionHandler handler = ConnectionHandler.getConnectionHandler();
         try {
             connectionName = getConnectionName(messageContext);
@@ -845,6 +845,11 @@ public class KafkaProduceConnector extends AbstractConnector {
             throw new SynapseException("Schema not found or error in obtaining the schema from the confluence schema registry", e);
         } catch (IOException | ConnectException | InvalidConfigurationException e) {
             throw new SynapseException("Error obtaining the schema from the confluence schema registry", e);
+        } finally {
+           //close the client connection to the schema registry
+            if (connection != null) {
+                handler.returnConnection(KafkaConnectConstants.CONNECTOR_NAME, connectionName, connection);
+            }
         }
         return jsonSchema;
     }
@@ -861,8 +866,8 @@ public class KafkaProduceConnector extends AbstractConnector {
     private Schema getSchemaFromVersionAndSubject(MessageContext messageContext, String schemaVersion,
                                                  String schemaSubject, boolean needSoftDeletedSchema) {
         io.confluent.kafka.schemaregistry.client.rest.entities.Schema schema;
-        String connectionName;
-        KafkaConnection connection;
+        String connectionName = null;
+        KafkaConnection connection = null;
         ConnectionHandler handler = ConnectionHandler.getConnectionHandler();
         try {
             connectionName = getConnectionName(messageContext);
@@ -879,6 +884,11 @@ public class KafkaProduceConnector extends AbstractConnector {
             }
         } catch (ConnectException | InvalidConfigurationException e) {
             throw new SynapseException("Error obtaining the schema from the confluence schema registry", e);
+        } finally {
+            // close the client connection to the schema registry
+            if (connection != null) {
+                handler.returnConnection(KafkaConnectConstants.CONNECTOR_NAME, connectionName, connection);
+            }
         }
         return new Schema.Parser().parse(schema.getSchema());
     }

--- a/src/main/resources/uischema/publishMessages.json
+++ b/src/main/resources/uischema/publishMessages.json
@@ -194,6 +194,17 @@
                     "required": "false",
                     "helpTip": "Whether soft deleted value schemas also need to be considered."
                   }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "kafkaHeaderPrefix",
+                    "displayName": "The Kafka header prefix to filter out the Kafka related headers from Message Context",
+                    "inputType": "string",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "Specify the Kafka header prefix to filter out the Kafka related headers from Message Context."
+                  }
                 }
               ]
             }


### PR DESCRIPTION
## Purpose

- Fix the issue where headers were not being properly sent to the Kafka broker.
- Fix the issue related to the custom header prefixes.

