### PR TITLE
Prevent null values from being converted to string 'null' in JSON payload

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -16,40 +16,7 @@
     ],
     "releases": [
         {
-            "tagName": "v3.3.4",
-            "products": [
-                "MI 4.0.0",
-                "MI 4.1.0",
-                "MI 4.2.0",
-                "MI 4.3.0",
-                "MI 4.4.0"
-            ],
-            "operations": [
-                {
-                    "name": "init",
-                    "description": "Configure the Kafka producer",
-                    "isHidden": true
-                },
-                {
-                    "name": "publishMessages",
-                    "description": "Send the messages to the Kafka brokers",
-                    "isHidden": false
-                }
-            ],
-            "connections": [
-                {
-                    "name": "kafka",
-                    "description": "Connection for a Kafka cluster."
-                },
-                {
-                    "name": "kafkaSecure",
-                    "description": "Secure connection for a Kafka cluster."
-                }
-            ],
-            "isHidden": false
-        },
-        {
-            "tagName": "v3.3.3",
+            "tagName": "v3.3.5",
             "products": [
                 "MI 4.0.0",
                 "MI 4.1.0",


### PR DESCRIPTION
## Purpose

Previously, the connector did not properly preserve null values in JSON payloads. This PR ensures that null values remain as null instead of being converted to the string "null". Fixes https://github.com/wso2/product-micro-integrator/issues/3992

Also, it fixes the following ClassCastException that may occur while getting the defaultValueNode if the defaultValue of the schema is configured as null.

```
[2025-02-17 13:35:51,367] ERROR {KafkaProduceConnector} - {api:kafkaTesting} Kafka producer connector : Error sending the message to broker java.lang.ClassCastException: class org.apache.avro.JsonProperties$Null cannot be cast to class com.fasterxml.jackson.databind.JsonNode (org.apache.avro.JsonProperties$Null is in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @4f039aee; com.fasterxml.jackson.databind.JsonNode is in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @36a87680)
```
